### PR TITLE
chore(deps): Bump tailwindcss and purgecss to newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   ],
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^2.1.2",
-    "tailwindcss": "^1.3.1"
+    "tailwindcss": "^1.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-tailwind",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "vue-cli plugin for Tailwind CSS",
   "author": "Jens Eggerstedt <j.eggerstedt@kaibatech.de>",
   "license": "MIT",
@@ -19,6 +19,6 @@
   ],
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^2.0.6",
-    "tailwindcss": "^1.2.0"
+    "tailwindcss": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-tailwind",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "vue-cli plugin for Tailwind CSS",
   "author": "Jens Eggerstedt <j.eggerstedt@kaibatech.de>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "purgecss"
   ],
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^2.0.6",
+    "@fullhuman/postcss-purgecss": "^2.1.2",
     "tailwindcss": "^1.3.1"
   }
 }


### PR DESCRIPTION
This PR will will upgrade tailwindcss to version ^1.3.4 and purgecss to version 2.1.2.
In addition the package version is set to 1.3.0.