### PR TITLE
 add postcss-loader as dependencies

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -62,6 +62,7 @@ module.exports = (api, options) => {
       autoprefixer: '^10',
       postcss: '^8',
       tailwindcss: '^3',
+      'postcss-loader': '^4.1.0',
     },
     postcss: {
       plugins: {


### PR DESCRIPTION
If the version of postcss-loader is less than 4.1.0, the loading will fail